### PR TITLE
Add `FORMAT` expression to format expression strings using string templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## [0.26.0] - 2023-06-02
+## [0.26.1] - 2023-06-02
+- [Add `FORMAT` expression to format expression strings using string templates](https://github.com/wiimag/wallet/pull/33)
 - Improve the pattern fundamentals dialog field value formatting.
 
 ## [0.25.13] - 2023-05-29

--- a/config/build.settings
+++ b/config/build.settings
@@ -14,7 +14,7 @@ PRODUCT_VERSIONS_URL=https://wallet.wiimag.com/versions
 # Version info
 VERSION_MAJOR=0
 VERSION_MINOR=26
-VERSION_PATCH=0
+VERSION_PATCH=1
 
 # Build settings (Usually passed to Cmake)
 BUILD_SERVICE_EXE=OFF

--- a/framework/string.cpp
+++ b/framework/string.cpp
@@ -2784,6 +2784,13 @@ FOUNDATION_STATIC string_t string_format_template_args(char* buffer, size_t capa
                 bufpos += string_from_int(buffer + bufpos, capacity - bufpos, array[j], t.precision, ' ').length;
             }
         }
+        else if (type == StringArgumentType::POINTER)
+        {
+            if (t.precision == 0)
+                bufpos += string_copy(buffer + bufpos, capacity - bufpos, "", 0).length;
+            else
+                bufpos += string_copy(buffer + bufpos, capacity - bufpos, STRING_CONST("null")).length;
+        }
         else
             FOUNDATION_ASSERT_FAIL("Invalid string argument type");
         


### PR DESCRIPTION
Add support for `FORMAT` to produce string templates, i.e.

```bash
$l = "Percent:"
$p = 44.519

FORMAT("{0} {1, 3} %", $l, $p) == "Percent: 44.5 %"
```

This can be useful to format report or watch cell values to your preferences, i.e.

![image](https://github.com/wiimag/wallet/assets/4054655/071319ba-3be4-432c-ac63-4f07269a72f5)

