### PR TITLE
Add support to register and execute application expression scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.30.0] - 2023-07-14
+- [Add support to register and execute script expressions](https://github.com/wiimag/wallet/pull/35)
+
 ## [0.29.1] - 2023-07-13
 - [Add pattern earnings view](https://github.com/wiimag/wallet/pull/34)
 

--- a/config/build.config
+++ b/config/build.config
@@ -13,8 +13,8 @@ PRODUCT_VERSIONS_URL=https://wallet.wiimag.com/versions
 
 # Version info
 VERSION_MAJOR=0
-VERSION_MINOR=29
-VERSION_PATCH=1
+VERSION_MINOR=30
+VERSION_PATCH=0
 
 # Build settings (Usually passed to Cmake)
 BUILD_SERVICE_EXE=OFF

--- a/config/locales.sjson
+++ b/config/locales.sjson
@@ -4040,5 +4040,40 @@
 			en = "\xee\xa1\xab {2, 3} ({1, 3} %)"
 			fr = "\xee\xa1\xab {2, 3} ({1, 3} %)"
 		}
+		{
+			hash = "657800105e26f173"
+			en = "Scripts"
+			fr = "Scripts"
+		}
+		{
+			hash = "77e0141c43cf00f3"
+			en = "Create..."
+			fr = "Créer..."
+		}
+		{
+			hash = "62e82732e1d7a2df"
+			en = "New script"
+			fr = "Nouveau script"
+		}
+		{
+			hash = "c7899c907ca7b66c"
+			en = "Edit script {0}"
+			fr = "Modifier le script {0}"
+		}
+		{
+			hash = "7631727ded1f71c7"
+			en = "{0} [Script]"
+			fr = "{0} [Script]"
+		}
+		{
+			hash = "8d75137e656e1dfa"
+			en = "Delete script?"
+			fr = "Supprimer le script?"
+		}
+		{
+			hash = "998597d88f40dc40"
+			en = "Delete script %s?"
+			fr = "Supprimer le script %s?"
+		}
 	]
 }

--- a/docs/expressions/report_next_earnings.expr
+++ b/docs/expressions/report_next_earnings.expr
@@ -10,7 +10,7 @@ $(next_report,
     $t = $1
     $e = F($t, "Earnings.History")
     $e = IF($e, MAP($e, [INDEX($2, 'reportDate'), INDEX($2, 'epsActual'), INDEX($2, 'epsEstimate')]), [nil, nill, nill])
-    $e = FILTER($e, IF($3, true, false) && IF($2, false, true))
+    $e = FILTER($e, IF($3, true, false) && $2 == nil)
     $e = IF($e, INDEX($e, -1), [])
 )
 

--- a/framework/expr.cpp
+++ b/framework/expr.cpp
@@ -1028,7 +1028,26 @@ FOUNDATION_STATIC expr_result_t expr_eval_if(const expr_func_t* f, vec_expr_t* a
     if (args->len < 2 || args->len > 3)
         throw ExprError(EXPR_ERROR_INVALID_ARGUMENT, "Invalid arguments");
 
-    expr_result_t condition = expr_eval(args->get(0));
+    expr_t* condarg = args->get(0);
+
+    // Check if the variable got resolved?
+    if (condarg->type == OP_VAR && condarg->token.length > 0)
+    {
+        if (condarg->param.var.value == nullptr)
+            return NIL;
+        if (condarg->param.var.value->type == EXPR_RESULT_SYMBOL)
+        {
+            string_const_t symstr = condarg->param.var.value->as_string();
+            if (string_equal(STRING_ARGS(condarg->token), STRING_ARGS(symstr)))
+            {
+                if (args->len == 2)
+                    return NIL;
+                return expr_eval(args->get(2));
+            }
+        }
+    }
+
+    expr_result_t condition = expr_eval(condarg);
     if (condition)
         return expr_eval(args->get(1));
 

--- a/framework/expr.h
+++ b/framework/expr.h
@@ -902,6 +902,9 @@ struct expr_result_t
         if (type == EXPR_RESULT_NULL)
             return false;
 
+        if (type == EXPR_RESULT_TRUE && rhs.type == EXPR_RESULT_NULL)
+            return false;
+
         if (type == EXPR_RESULT_TRUE && rhs.type == EXPR_RESULT_TRUE)
             return true;
         if (type == EXPR_RESULT_FALSE && rhs.type == EXPR_RESULT_FALSE)

--- a/framework/expr.h
+++ b/framework/expr.h
@@ -608,6 +608,8 @@ struct expr_result_t
             return false;
         if (type == EXPR_RESULT_NUMBER && math_real_is_zero(value))
             return false;
+        if (type == EXPR_RESULT_SYMBOL && value == 0.0)
+            return false;
         return !is_null();
     }
 

--- a/framework/imgui.h
+++ b/framework/imgui.h
@@ -559,4 +559,13 @@ namespace ImGui
     {
         return ImGui::GetIO().WantTextInput;
     }
+
+    /*! Get the current content region available width. 
+     * 
+     *  @return The current content region available width.
+     */
+    FOUNDATION_FORCEINLINE float GetContentRegionAvailWidth()
+    {
+        return ImGui::GetContentRegionAvail().x;
+    }
 }

--- a/framework/table_expr.cpp
+++ b/framework/table_expr.cpp
@@ -137,7 +137,12 @@ FOUNDATION_STATIC table_cell_t table_expr_cell_value(const table_expr_record_val
         return table_cell_t(false);
 
     if (v->type == DYNAMIC_TABLE_VALUE_TEXT)
+    {
+        if (format == COLUMN_FORMAT_DATE)
+            return string_to_date(STRING_ARGS(v->text));
+
         return table_cell_t(string_to_const(v->text));
+    }
 
     if (v->type == DYNAMIC_TABLE_VALUE_NUMBER)
     {

--- a/sources/scripts.cpp
+++ b/sources/scripts.cpp
@@ -1,0 +1,329 @@
+/*
+ * License: https://wiimag.com/LICENSE
+ * Copyright 2023 Wiimag Inc. All rights reserved.
+ */
+
+#include "scripts.h"
+
+#include <framework/app.h>
+#include <framework/module.h>
+#include <framework/memory.h>
+#include <framework/session.h>
+#include <framework/array.h>
+#include <framework/window.h>
+#include <framework/expr.h>
+#include <framework/console.h>
+
+struct SCRIPTS_MODULE
+{
+    script_t* scripts{};
+
+} *_{ nullptr };
+
+#define HASH_SCRIPTS static_hash_string("scripts", 7, 0xf71318a2c32e8e7eULL)
+
+//
+// PRIVATE
+//
+
+FOUNDATION_STATIC string_const_t scripts_config_path()
+{
+    return session_get_user_file_path(STRING_CONST("scripts.json"));
+}
+
+FOUNDATION_STATIC script_t* scripts_load()
+{
+    script_t* scripts = nullptr;
+
+    config_handle_t cv;
+    string_const_t scripts_config_file_path = scripts_config_path();
+    if (fs_is_file(STRING_ARGS(scripts_config_file_path)))
+        cv = config_parse_file(STRING_ARGS(scripts_config_file_path), CONFIG_OPTION_PRESERVE_INSERTION_ORDER);
+    else
+        cv = config_allocate(CONFIG_VALUE_ARRAY);
+
+    for (auto e : cv)
+    {
+        if (config_type(e) != CONFIG_VALUE_OBJECT)
+            continue;
+
+        string_const_t name = e["name"].as_string();
+        string_const_t text = e["text"].as_string();
+
+        script_t script{};
+        string_copy(STRING_BUFFER(script.name), STRING_ARGS(name));
+        string_copy(STRING_BUFFER(script.text), STRING_ARGS(text));
+        
+        script.last_executed = e["last_executed"].as_time();
+        script.last_modified = e["last_modified"].as_time();
+
+        script.show_console = e["show_console"].as_boolean(false);
+        script.load_on_startup = e["load_on_startup"].as_boolean(false);
+
+        array_push_memcpy(scripts, &script);
+    }
+
+    config_deallocate(cv);
+
+    return array_sort(scripts, ARRAY_COMPARE_EXPRESSION(b.last_executed - a.last_executed));
+}
+
+FOUNDATION_STATIC void scripts_save(script_t* scripts)
+{
+    config_handle_t data = config_allocate(CONFIG_VALUE_ARRAY);
+
+    for (unsigned i = 0, count = array_size(scripts); i< count; ++i)
+    {
+        script_t* script = scripts + i;
+        
+        config_handle_t cv = config_array_push(data, CONFIG_VALUE_OBJECT);
+
+        config_set(cv, "name", STRING_LENGTH(script->name));
+        config_set(cv, "text", STRING_LENGTH(script->text));
+
+        config_set(cv, "last_executed", (double)script->last_executed);
+        config_set(cv, "last_modified", (double)script->last_modified);
+
+        config_set(cv, "show_console", script->show_console);
+        config_set(cv, "load_on_startup", script->load_on_startup);
+    }
+
+    string_const_t scripts_config_file_path = scripts_config_path();
+    config_write_file(scripts_config_file_path, data, CONFIG_OPTION_WRITE_NO_SAVE_ON_DATA_EQUAL);
+    config_deallocate(data);
+}
+
+FOUNDATION_STATIC bool script_evaluate(script_t* script)
+{
+    auto result = eval(STRING_LENGTH(script->text));
+    if (EXPR_ERROR_CODE != EXPR_ERROR_NONE)
+    {
+        char formatted_name_buffer[256];
+        string_t formatted_name = string_utf8_unescape(STRING_BUFFER(formatted_name_buffer), STRING_LENGTH(script->name));
+        log_errorf(HASH_SCRIPTS, ERROR_SCRIPT, STRING_CONST("Failed to evaluate script '%.*s': %s"),
+            STRING_FORMAT(formatted_name), EXPR_ERROR_MSG);
+        console_show();
+    }
+    script->last_executed = time_now();
+    array_sort(_->scripts, ARRAY_COMPARE_EXPRESSION(b.last_executed - a.last_executed));
+    return result.as_boolean();
+}
+
+FOUNDATION_STATIC void script_render_window(window_handle_t win)
+{
+    script_t* script = (script_t*)window_get_user_data(win);
+    FOUNDATION_ASSERT(script != nullptr);
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::TrTextUnformatted("Name");
+
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x * 0.3f);
+    if (ImGui::InputText("##Name", STRING_BUFFER(script->name)))
+    {
+        script->last_modified = time_now();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Show console", &script->show_console))
+    {
+        script->last_modified = time_now();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Run on startup", &script->load_on_startup))
+    {
+        script->last_modified = time_now();
+    }
+
+    ImGui::BeginDisabled(string_length(script->name) == 0 || string_length(script->text) == 0);
+    if (script->is_new)
+    {
+        ImGui::SameLine();
+        if (ImGui::Button(tr("Create")))
+        {
+            script->last_executed = time_now();
+            script->last_modified = time_now();
+            script->is_new = false;
+            window_close(win);
+        }
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button(tr("Evaluate")))
+    {
+        script_evaluate(script);
+    }
+    ImGui::EndDisabled();
+
+    if (!script->is_new)
+    {
+        ImGui::SameLine();
+        if (ImGui::Button(tr("Delete")))
+        {
+            ImGui::OpenPopup(tr("Delete script?"));
+        }
+
+        if (ImGui::BeginPopupModal(tr("Delete script?"), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            char formatted_name_buffer[256];
+            string_t formatted_name = string_utf8_unescape(STRING_BUFFER(formatted_name_buffer), STRING_LENGTH(script->name));
+            ImGui::TrText("Delete script %.*s?", STRING_FORMAT(formatted_name));
+            ImGui::Separator();
+
+            if (ImGui::Button(tr("Delete"), { ImGui::GetContentRegionAvailWidth() * 0.5f, 0.0f }))
+            {
+                ImGui::CloseCurrentPopup();
+                array_erase_ordered_safe(_->scripts, (unsigned)(script - _->scripts));
+                window_close(win);
+            }
+
+            ImGui::SameLine();
+            if (ImGui::Button(tr("Cancel"), { ImGui::GetContentRegionAvailWidth(), 0.0f }))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        }
+    }
+
+    if (ImGui::InputTextMultiline("##Expression", STRING_BUFFER(script->text), ImGui::GetContentRegionAvail()))
+    {
+        script->last_modified = time_now();
+    }
+}
+
+FOUNDATION_STATIC void script_close_new(window_handle_t win)
+{
+    script_t* new_script = (script_t*)window_get_user_data(win);
+    if (!new_script->is_new)
+    {
+        array_push_memcpy(_->scripts, new_script);
+    }
+
+    if (new_script)
+        MEM_DELETE(new_script);
+}
+
+FOUNDATION_STATIC void scripts_create_new()
+{
+    script_t* new_script = MEM_NEW(HASH_SCRIPTS, script_t);
+    new_script->is_new = true;
+
+    string_const_t title = RTEXT("New script");
+    window_open(HASH_SCRIPTS, STRING_ARGS(title), script_render_window, script_close_new, new_script);
+}
+
+FOUNDATION_STATIC void scripts_menu()
+{
+    script_t* scripts = _->scripts;
+
+    if(!ImGui::BeginMenuBar())
+        return;
+
+    if (!ImGui::TrBeginMenu("Scripts"))
+        return ImGui::EndMenuBar();
+
+    if (ImGui::TrMenuItem("Create..."))
+        scripts_create_new();
+
+    const unsigned scrit_count = array_size(scripts);
+
+    if (scrit_count)
+        ImGui::Separator();
+
+    float max_label_width = 100.0f;
+    for (unsigned i = 0, count = scrit_count; i < count; ++i)
+    {
+        script_t* script = scripts + i;
+        max_label_width = math_max(max_label_width, ImGui::CalcTextSize(script->name).x);
+    }
+    
+    for (unsigned i = 0, count = scrit_count; i < count; ++i)
+    {
+        script_t* script = scripts + i;
+
+        char menu_name_buffer[256];
+        string_t menu_name = string_utf8_unescape(STRING_BUFFER(menu_name_buffer), STRING_LENGTH(script->name));
+
+        ImGui::PushID(script);
+        ImGui::BeginGroup();
+        if (ImGui::Selectable(menu_name.str, false, ImGuiSelectableFlags_AllowItemOverlap, {max_label_width, 0.0f}))
+        {
+            script_evaluate(script);
+        }
+        else if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+        {
+            ImGui::SetTooltip("%s", script->text);
+        }
+
+        ImGui::SameLine(max_label_width + IM_SCALEF(12));
+        
+        if (ImGui::SmallButton(ICON_MD_EDIT))
+        {
+            char formatted_name_buffer[256];
+            string_t formatted_name = string_utf8_unescape(STRING_BUFFER(formatted_name_buffer), STRING_LENGTH(script->name));
+            string_t title = tr_format(SHARED_BUFFER(256), "{0} [Script]", formatted_name);
+            window_open(HASH_SCRIPTS, STRING_ARGS(title), script_render_window, nullptr, script);
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::SmallButton(ICON_MD_DELETE_FOREVER))
+        {
+            ImGui::OpenPopup(tr("Delete script?"));
+        }
+
+        if (ImGui::BeginPopupModal(tr("Delete script?"), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            char formatted_name_buffer[256];
+            string_t formatted_name = string_utf8_unescape(STRING_BUFFER(formatted_name_buffer), STRING_LENGTH(script->name));
+            ImGui::TrText("Delete script %.*s?", STRING_FORMAT(formatted_name));
+            ImGui::Separator();
+
+            if (ImGui::Button(tr("Delete"), { ImGui::GetContentRegionAvailWidth() * 0.5f, 0.0f }))
+            {
+                array_erase_ordered_safe(_->scripts, i);
+                i--;
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::SameLine();
+            if (ImGui::Button(tr("Cancel"), { ImGui::GetContentRegionAvailWidth(), 0.0f }))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        }
+
+        ImGui::EndGroup();
+        ImGui::PopID();
+    }
+
+    ImGui::EndMenu();
+    ImGui::EndMenuBar();
+}
+
+//
+// SYSTEM
+//
+
+FOUNDATION_STATIC void scripts_init()
+{
+    _ = MEM_NEW(HASH_SCRIPTS, SCRIPTS_MODULE);
+
+    _->scripts = scripts_load();
+    module_register_menu(HASH_SCRIPTS, scripts_menu);
+}
+
+FOUNDATION_STATIC void scripts_shutdown()
+{
+    scripts_save(_->scripts);
+    array_deallocate(_->scripts);
+
+    MEM_DELETE(_);
+}
+
+DEFINE_MODULE(SCRIPTS, scripts_init, scripts_shutdown, MODULE_PRIORITY_MODULE);

--- a/sources/scripts.h
+++ b/sources/scripts.h
@@ -1,0 +1,30 @@
+/*
+ * License: https://wiimag.com/LICENSE
+ * Copyright 2023 Wiimag Inc. All rights reserved.
+ *
+ * The script modules allow the user to create expression scripts that are easily executed from the UI.
+ */
+
+#pragma once
+
+#include <framework/config.h>
+
+typedef enum {
+
+    SCRIPT_UNDEFINED,
+    SCRIPT_EXPRESSION
+
+} script_point_type_t;
+
+struct script_t
+{;
+    char name[256]{0};
+    char text[64 * 1024]{0};
+
+    time_t last_modified{ 0 };
+    time_t last_executed{ 0 };
+    bool show_console{ false };
+    bool load_on_startup{ false };
+
+    bool is_new{ false };
+};


### PR DESCRIPTION
## Add support to create new application expression scripts

![image](https://github.com/wiimag/wallet/assets/4054655/dfacaa49-3630-473d-bf6d-3eb770429cae)

## Edit scripts

![image](https://github.com/wiimag/wallet/assets/4054655/085762f5-3797-4f0d-8d2e-9cbc916b987a)

![image](https://github.com/wiimag/wallet/assets/4054655/58bfb478-5fad-4bc2-9b6f-640592ba4cf7)

## Execute scripts from the main menu

![image](https://github.com/wiimag/wallet/assets/4054655/d9b8df4b-f4df-4f6a-957d-8b136ffb6054)

### After the script was executed (here the script created a [table](https://wallet.wiimag.com/manual/en/expressions.md#tabletitle-set-columns))

![image](https://github.com/wiimag/wallet/assets/4054655/56333c10-34b8-4e07-9f20-9cd830e6f6cf)


